### PR TITLE
fix: Fix footer background not spanning full viewport width

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="min-h-screen flex flex-col">
+          <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-black transition-colors">
             <Navbar config={config} />
             <main className="flex-1">{children}</main>
             <Footer config={config} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
   const w4 = totalCount(month) - totalCount(week3);
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-black transition-colors">
+    <div className="min-h-screen transition-colors">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10 space-y-14">
         <section className="text-center space-y-4">
           <h1 className="text-5xl sm:text-5xl lg:text-7xl font-bold tracking-tight bg-clip-text text-transparent bg-linear-to-r from-[#50B78B] via-[#60C79B] to-[#70D7AB]


### PR DESCRIPTION
Root Cause

The issue was caused by a redundant outer wrapper in app/page.tsx that applied:

**min-h-screen bg-zinc-50 dark:bg-black**

This introduced an unintended nested layout:
	•	The page content was wrapped in its own full-height container with background colors.
	•	The footer, which is defined at the layout.tsx level, was outside this wrapper.
	•	Because the background styling was applied to the inner page wrapper instead of the layout, the footer appeared visually boxed-in rather than spanning the full viewport width.

Solution
	•	Removed the redundant outer wrapper from page.tsx.
	•	Retained only the inner content container with the max-w-7xl constraint.
	•	Background styling is now correctly handled at the layout.tsx level.
	
Testing

- Verified at 1500px viewport width
- Tested in both dark and light modes
- Footer now correctly spans full width without side gaps

<img width="1277" height="553" alt="Screenshot 2025-12-26 at 2 56 09 AM" src="https://github.com/user-attachments/assets/e1095026-aea6-4e30-92fe-e37e6a61b067" />

fixes #13 