### PR TITLE
Fix: Overlapping of label "High"

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,10 @@ body::selection {
   background-color: #50B78B4d;
 }
 
+.recharts-surface {
+  padding: 10px;  
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {


### PR DESCRIPTION
## Description
This PR fixes the overlapping **“High”** label in the **Total Activities** chart by adjusting its positioning to prevent it from overlapping with the graph line and data point, improving readability and visual clarity.

## Related Issue
Fixes #15 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/07aef3eb-c73b-4844-b2d7-4bbe59437c6d" width="260" /> | <img src="https://github.com/user-attachments/assets/a4947b4c-b3a4-4a86-9d0a-7d43b6f86b28" width="260" /> |
