### PR TITLE
pagination UI enhancement, fix #17

### DIFF
--- a/components/PaginatedActivitySection.tsx
+++ b/components/PaginatedActivitySection.tsx
@@ -47,27 +47,15 @@ export function PaginatedActivitySection({
 
   const getPageNumbers = () => {
     const pages: (number | string)[] = [];
-    const maxVisible = 5;
 
-    if (totalPages <= maxVisible) {
+    if (totalPages <= 4) {
+      // Show all pages if 4 or fewer
       for (let i = 1; i <= totalPages; i++) pages.push(i);
     } else {
-      pages.push(1);
-
-      if (currentPage <= 3) {
-        for (let i = 2; i <= 4; i++) pages.push(i);
-        pages.push("...");
-        pages.push(totalPages);
-      } else if (currentPage >= totalPages - 2) {
-        pages.push("...");
-        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i);
-      } else {
-        pages.push("...");
-        for (let i = currentPage - 1; i <= currentPage + 1; i++)
-          pages.push(i);
-        pages.push("...");
-        pages.push(totalPages);
-      }
+      // Show: 1 2 3 ... last
+      pages.push(1, 2, 3);
+      pages.push("...");
+      pages.push(totalPages);
     }
 
     return pages;
@@ -156,76 +144,66 @@ export function PaginatedActivitySection({
 
         {/* Pagination Controls */}
         {totalPages > 1 && (
-          <div className="bg-zinc-50 dark:bg-white/5 px-4 py-4 border-t">
-            <div className="flex flex-col items-center gap-2">
-              <div className="flex items-center gap-1 sm:gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={goToPrevious}
-                  disabled={currentPage === 1}
-                  className="h-8 px-2 sm:px-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] transition-colors disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-inherit disabled:cursor-not-allowed cursor-pointer"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline">Previous</span>
-                </Button>
+          <div className="bg-zinc-50 dark:bg-white/5 px-4 py-3 border-t">
+            <div className="flex items-center justify-center gap-1 sm:gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={goToPrevious}
+                disabled={currentPage === 1}
+                className="h-8 px-2 sm:px-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] transition-colors disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-inherit disabled:cursor-not-allowed cursor-pointer"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                <span className="hidden sm:inline">Previous</span>
+              </Button>
 
-                <div className="flex items-center gap-1">
-                  {getPageNumbers().map((page, index) => {
-                    if (page === "...") {
-                      return (
-                        <span
-                          key={`ellipsis-${index}`}
-                          className="px-2 text-xs text-zinc-400"
-                        >
-                          ...
-                        </span>
-                      );
-                    }
-
-                    const pageNum = page as number;
+              <div className="flex items-center gap-1">
+                {getPageNumbers().map((page, index) => {
+                  if (page === "...") {
                     return (
-                      <Button
-                        key={pageNum}
-                        variant={
-                          currentPage === pageNum ? "default" : "ghost"
-                        }
-                        size="sm"
-                        onClick={() => goToPage(pageNum)}
-                        className={`h-8 w-8 p-0 transition-all cursor-pointer ${
-                          currentPage === pageNum
-                            ? "bg-[#50B78B] hover:bg-[#50B78B]/90 text-white shadow-sm"
-                            : "hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] hover:border-[#50B78B]/20 hover:shadow-sm"
-                        }`}
+                      <span
+                        key={`ellipsis-${index}`}
+                        className="px-2 text-xs text-zinc-400"
                       >
-                        {pageNum}
-                      </Button>
+                        ...
+                      </span>
                     );
-                  })}
-                </div>
+                  }
 
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={goToNext}
-                  disabled={currentPage === totalPages}
-                  className="h-8 px-2 sm:px-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] transition-colors disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-inherit disabled:cursor-not-allowed cursor-pointer"
-                >
-                  <span className="hidden sm:inline">Next</span>
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
+                  const pageNum = page as number;
+                  return (
+                    <Button
+                      key={pageNum}
+                      variant={
+                        currentPage === pageNum ? "default" : "ghost"
+                      }
+                      size="sm"
+                      onClick={() => goToPage(pageNum)}
+                      className={`h-8 w-8 p-0 transition-all cursor-pointer ${
+                        currentPage === pageNum
+                          ? "bg-[#50B78B] hover:bg-[#50B78B]/90 text-white shadow-sm"
+                          : "hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] hover:border-[#50B78B]/20 hover:shadow-sm"
+                      }`}
+                    >
+                      {pageNum}
+                    </Button>
+                  );
+                })}
               </div>
 
-              <div className="text-xs text-zinc-500 hidden sm:block mt-2 mb-[-8]">
-                Page {currentPage} of {totalPages}
-              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={goToNext}
+                disabled={currentPage === totalPages}
+                className="h-8 px-2 sm:px-3 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B] transition-colors disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-inherit disabled:cursor-not-allowed cursor-pointer"
+              >
+                <span className="hidden sm:inline">Next</span>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
             </div>
           </div>
         )}
-
-        <div className="bg-zinc-50 dark:bg-white/5 px-4 py-2 text-[10px] text-center text-zinc-400 uppercase tracking-widest">
-          Activity Stream
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
Cleaned up the pagination UI by removing redundant elements and simplified the page number display logic. The pagination now shows a cleaner format: `Previous 1 2 3 ... 20 Next` when there are more than 4 pages.

## Related Issue
Fixes #17 

## Type of change
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation

## Changes Made
1. **Removed redundant UI elements:**
   - Removed "ACTIVITY STREAM" footer label
   - Removed "Page X of Y" text below pagination buttons

2. **Simplified pagination logic:**
   - Changed `getPageNumbers()` function to show a consistent format
   - When totalPages ≤ 4: Shows all page numbers (e.g., `1 2 3 4`)
   - When totalPages > 4: Shows first 3 pages, ellipsis, and last page (e.g., `1 2 3 ... 20`)
   - Removed complex conditional logic for current page positioning

3. **UI improvements:**
   - Centered pagination controls
   - Reduced visual clutter
   - Maintained responsive design for mobile/desktop

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

**Dark theme:**

<img width="1338" height="150" alt="image" src="https://github.com/user-attachments/assets/5ee7413b-ea7b-4990-b86e-9c719d799dd0" />

**Light theme:**

<img width="1347" height="173" alt="image" src="https://github.com/user-attachments/assets/fd964efc-1335-41dc-91e8-9ee2b6971c11" />
