### PR TITLE
fix: use absolute paths for footer social media icons

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -63,7 +63,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="Facebook"
                 >
                   <Image
-                    src="facebook.svg"
+                    src="/facebook.svg"
                     alt="Facebook"
                     width={20}
                     height={20}
@@ -79,7 +79,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="YouTube"
                 >
                   <Image
-                    src="youtube.svg"
+                    src="/youtube.svg"
                     alt="YouTube"
                     width={20}
                     height={20}
@@ -95,7 +95,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="Twitter"
                 >
                   <Image
-                    src="twitter.svg"
+                    src="/twitter.svg"
                     alt="Twitter"
                     width={20}
                     height={20}
@@ -112,7 +112,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="LinkedIn"
                 >
                   <Image
-                    src="linkedIn.svg"
+                    src="/linkedIn.svg"
                     alt="LinkedIn"
                     width={20}
                     height={20}
@@ -128,7 +128,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="GitHub"
                 >
                   <Image
-                    src="github.svg"
+                    src="/github.svg"
                     alt="GitHub"
                     width={20}
                     height={20}
@@ -144,7 +144,7 @@ export const Footer = async ({ config }: FooterProps) => {
                   aria-label="Email"
                 >
                   <Image
-                    src="gmail.svg"
+                    src="/gmail.svg"
                     alt="Email"
                     width={20}
                     height={20}


### PR DESCRIPTION
## Root Cause
The `Image` components in [components/footer.tsx](cci:7://file:///Users/hmshuu/Desktop/dashboard/community-dashboard/components/footer.tsx:0:0-0:0) used **relative paths** (e.g., `src="linkedIn.svg"`) instead of **absolute paths** (e.g., `src="/linkedIn.svg"`).

In Next.js, relative paths in the `Image` component resolve relative to the current route, causing 500 errors on nested pages.

## Solution
Updated all 6 social media icon `src` attributes to use absolute paths starting with `/` to correctly reference files in the `public` directory.

## Changes
| Icon | Before | After |
|------|--------|-------|
| Facebook | `"facebook.svg"` | `"/facebook.svg"` |
| YouTube | `"youtube.svg"` | `"/youtube.svg"` |
| Twitter | `"twitter.svg"` | `"/twitter.svg"` |
| LinkedIn | `"linkedIn.svg"` | `"/linkedIn.svg"` |
| GitHub | `"github.svg"` | `"/github.svg"` |
| Email | `"gmail.svg"` | `"/gmail.svg"` |

## Testing
- ✅ Verified icons load on Home page (`/`)
- ✅ Verified icons load on nested pages (`/leaderboard/`, `/people/`)
- ✅ No console errors for SVG assets
<img width="650" height="264" alt="Screenshot 2025-12-26 at 8 02 07 PM" src="https://github.com/user-attachments/assets/d93f5136-4678-413d-a7bc-594600007c35" />

fixes #22 
