### PR TITLE
fix: add suppressHydrationWarning to body tag to prevent hydration mismatch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,6 +51,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${figtree.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
## Root Cause
The `next-themes` package applies theme classes (e.g., `dark`, `light`) to the `<body>` tag on the client side after hydration. Since the server doesn't know the user's theme preference during SSR, the `className` differs between server and client.

## Solution
Added `suppressHydrationWarning` to the `<body>` tag in [app/layout.tsx](cci:7://file:///Users/hmshuu/Desktop/dashboard/community-dashboard/app/layout.tsx:0:0-0:0). This tells React to expect potential mismatches on this element and suppress the warning, which is the recommended approach when using `next-themes`.

## Changes
- [app/layout.tsx](cci:7://file:///Users/hmshuu/Desktop/dashboard/community-dashboard/app/layout.tsx:0:0-0:0): Added `suppressHydrationWarning` prop to `<body>` tag

## Testing
- ✅ Verified no hydration errors on Home page
- ✅ Verified no hydration errors on Leaderboard page  
- ✅ Verified no hydration errors on People page
- ✅ No "1 Issue" badge appears in dev overlay

fixes #27 