### PR TITLE
fix: use consistent activity pill order across all contributor rows

### DIFF
--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -391,7 +391,21 @@ export default function LeaderboardView({
                           {/* Activity Breakdown */}
                           <div className="flex flex-wrap gap-3">
                             {Object.entries(entry.activity_breakdown)
-                              .sort((a, b) => b[1].points - a[1].points)
+                              .sort((a, b) => {
+                                // Predefined priority order for consistent display across rows
+                                const activityPriority: Record<string, number> = {
+                                  "PR merged": 1,
+                                  "PR opened": 2,
+                                  "Issue opened": 3,
+                                };
+                                const priorityA = activityPriority[a[0]] ?? 99;
+                                const priorityB = activityPriority[b[0]] ?? 99;
+                                // Sort by priority first, then alphabetically for unknown activities
+                                if (priorityA !== priorityB) {
+                                  return priorityA - priorityB;
+                                }
+                                return a[0].localeCompare(b[0]);
+                              })
                               .map(([activityName, data]) => (
                                 <div
                                   key={activityName}


### PR DESCRIPTION
**Before:**
| Contributor | Activity Order |
|-------------|----------------|
| himanshujays29 | `PR merged (+10)` → `PR opened (+4)` |
| naman79820 | `PR merged (+5)` → `Issue opened (+4)` → `PR opened (+2)` |

**After:**
| Contributor | Activity Order (consistent) |
|-------------|----------------|
| himanshujays29 | `PR merged (+10)` → `PR opened (+4)` |
| naman79820 | `PR merged (+5)` → `PR opened (+2)` → `Issue opened (+4)` |

## Changes
- [components/Leaderboard/LeaderboardView.tsx](cci:7://file:///Users/hmshuu/Desktop/dashboard/community-dashboard/components/Leaderboard/LeaderboardView.tsx:0:0-0:0): Updated activity pill sorting logic

## Testing
- ✅ All contributor rows now display activities in consistent order
- ✅ Same activity types align vertically across rows for easy comparison
- ✅ Unknown activity types fallback to alphabetical order

fixes #31 