### PR TITLE
github_icon_fixed_inside_the_navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -84,7 +84,7 @@ const Navbar = ({ config }: NavbarProps) => {
             >
               <Button variant={"outline"} size={"icon"}>
                 <Image
-                  src="github.svg"
+                  src="/github.svg"
                   alt="GitHub"
                   width={17}
                   height={17}


### PR DESCRIPTION
**Description**
Fixes the GitHub icon in the navbar not showing up on some pages by using an absolute asset path (/github.svg) instead of a relative one, so it loads correctly on nested routes.
**Related Issue**
Fixes #25 
**Type of change**
[x] Bug fix
[ ] Feature
[ ] Refactor
[ ] Documentation
**Checklist**
[x] Code follows project style
[x] Tested locally (checked on /leaderboard/month)
[x] No unnecessary files added
[x] PR title is clear and descriptive