### PR TITLE
Fix: CircuitVerse Logo Now Redirects to Homepage

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -39,7 +39,7 @@ const Navbar = ({ config }: NavbarProps) => {
         <div className="relative mx-auto px-4 h-16 flex items-center justify-between">
           {/* Logo */}
           <Link
-            href="https://circuitverse.org/"
+            href="/"
             className="flex items-center gap-3"
           >
             <Image


### PR DESCRIPTION
## Description
This PR fixes an issue where clicking the CircuitVerse logo in the top-left corner of the interface did not redirect users to the main homepage. The logo now correctly navigates users back to the home page, aligning with standard UI/UX expectations.

## Related Issue
Fixes #37 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

https://github.com/user-attachments/assets/21281854-7587-4edb-9c9d-3447051ec2a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated navigation links**: The application logo now directs to the CircuitVerse website instead of the home page. The About Us section is now clickable and links to the CircuitVerse website, opening in a new tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->