### PR TITLE
Fix contributor name overflow in profile card layout

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -23,6 +23,8 @@ import {
   ExternalLink
 } from "lucide-react";
 
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
 interface ContributorEntry {
   username: string;
   name: string | null;
@@ -116,8 +118,11 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
   const monthlyPoints = monthlyActivity.reduce((sum, day) => sum + day.points, 0);
   const monthlyDays = monthlyActivity.length;
 
+  const displayName = contributor.name || contributor.username;
+  const displayUsername = `@${contributor.username}`;
+
   return (
-    <div className="mx-auto px-4 py-8 max-w-7xl">
+    <div className="mx-auto px-4 py-8 max-w-7xl lg:max-w-[1300px]">
       <Button onClick={onBack} variant="outline" className="mb-6 hover:bg-primary cursor-pointer transition-colors">
         <ArrowLeft className="w-4 h-4 mr-2" />
         Back to People
@@ -148,9 +153,28 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
                   )}
                 </div>
                 
-                <div className="text-center w-full">
-                  <h2 className="text-2xl font-bold mb-2">{contributor.name || contributor.username}</h2>
-                  <p className="text-muted-foreground mb-3 text-lg">@{contributor.username}</p>
+                <div className="text-center w-full min-w-0 px-4">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <h2 className="text-2xl font-bold mb-2 truncate max-w-full min-w-0" aria-label={displayName}>
+                        {displayName}
+                      </h2>
+                    </TooltipTrigger>
+                    <TooltipContent sideOffset={6} side="top">
+                      {displayName}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <p className="text-muted-foreground mb-3 text-lg truncate max-w-full min-w-0" aria-label={displayUsername}>
+                        {displayUsername}
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent sideOffset={6} side="bottom">
+                      {displayUsername}
+                    </TooltipContent>
+                  </Tooltip>
                   <Badge variant="secondary" className="mb-6 bg-primary/10 text-primary font-semibold px-4 py-2">
                     {contributor.role}
                   </Badge>


### PR DESCRIPTION
## Description
This PR fixes a UI layout issue on the **People → Contributor profile page** where long contributor usernames were overflowing outside the profile card.

**Changes included:**
- Truncated long contributor usernames using an ellipsis (`...`)
- Added a tooltip to display the full username on interaction
- Ensured the contributor name stays within the card on all screen sizes

## Related Issue
Fixes #47 

## Type of change
- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots 
**Before**
- Long contributor username overflows outside the profile card
- Layout breaks and text goes out of bounds

<img width="1603" height="972" alt="Screenshot 2025-12-30 090716" src="https://github.com/user-attachments/assets/f1e1fcd4-d3c8-474d-bfbc-3de7e3900322" />

**After**
- Contributor username is truncated with an ellipsis (`...`)
- Tooltip shows the full username on interaction

<img width="1900" height="910" alt="Screenshot 2025-12-30 222338" src="https://github.com/user-attachments/assets/2ebbe664-5190-4c27-8c17-6be5a7519bb9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive tooltips that display full contributor names and usernames on hover.

* **Improvements**
  * Enhanced contributor profile layout with improved responsiveness and truncated text display for better visual polish.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->