### PR TITLE
fix: Update Pagination state for pages beyond 3

### DIFF
--- a/components/PaginatedActivitySection.tsx
+++ b/components/PaginatedActivitySection.tsx
@@ -192,7 +192,7 @@ export function PaginatedActivitySection({
                 </Button>
 
                 <div className="flex items-center gap-1">
-                  {getPageNumbers().map((pageNum, index) => (
+                  {getPageNumbers().map((pageNum) => (
                     <Button
                       key={`${windowStart}-${pageNum}`}
                       variant={currentPage === pageNum ? "default" : "ghost"}
@@ -206,7 +206,35 @@ export function PaginatedActivitySection({
                     >
                       {pageNum}
                     </Button>
-                  ))}
+                  ))}  
+                  {(() => { 
+                    const windowEnd = windowStart + windowSize - 1;
+                    if(windowEnd >= totalPages) return null;
+                    const PageButton = (page: number) => (
+                      <Button
+                        key={`${windowStart}-${page}`}
+                        variant={currentPage === page ? "default" : "ghost"}
+                        size="sm"
+                        onClick={() => goToPage(page)}
+                        className={`h-8 w-8 p-0 cursor-pointer ${
+                          currentPage === page
+                            ? "bg-[#50B78B] text-white"
+                            : "hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-[#50B78B]"
+                        }`}
+                      >
+                        {page}
+                      </Button>
+                    );
+                    if(windowEnd === totalPages - 1){
+                      return PageButton(totalPages);
+                    }
+                    return(
+                      <>
+                        <span className="px-1 text-zinc-400">…</span>
+                        {PageButton(totalPages)}
+                      </>
+                    );
+                  })()}
                 </div>
 
                 <Button


### PR DESCRIPTION
## Description
this PR fixes a pagination issue in the Recent Activities section
for activity boxes with more than 3 pages, pages after page 3 were not shown or highlighted, even though the content changed 
this update makes sure the correct page number is visible and highlighted

## Related Issue
Fixes #68 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
**Before**


https://github.com/user-attachments/assets/df240545-e049-4eb0-bccb-a5bd851b8e6a


**After**




https://github.com/user-attachments/assets/bce727fb-5563-4ca1-9538-d642a1ef4577




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination navigation: Previous/Next now shift a sliding window of visible page numbers so the active page stays in view.

* **Refactor**
  * Redesigned pagination UI to a compact windowed control showing contiguous page numbers and an explicit current/total display, removing prior ellipses behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->