### PR TITLE
Fix month-over-month statistics by comparing correct date ranges

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import { PaginatedActivitySection } from "@/components/PaginatedActivitySection"
 
 import {
   ActivityGroup,
+  getMonthlyActivityBuckets,
+  getPreviousMonthActivityCount,
   getRecentActivitiesGroupedByType,
 } from "@/lib/db";
 
@@ -18,23 +20,25 @@ export default async function Home() {
   const totalCount = (groups: ActivityGroup[]) =>
     groups.reduce((sum, g) => sum + g.activities.length, 0);
 
-  const week = await getRecentActivitiesGroupedByType("week");
-  const week2 = await getRecentActivitiesGroupedByType("2week");
-  const week3 = await getRecentActivitiesGroupedByType("3week");
-  const month = await getRecentActivitiesGroupedByType("month");
-  const month2 = await getRecentActivitiesGroupedByType("2month");
+  const week = await getRecentActivitiesGroupedByType(
+    "week"
+  );
+  const month = await getRecentActivitiesGroupedByType(
+    "month"
+  );
 
-  const w1 = totalCount(week);
-  const w2 = totalCount(week2) - w1;
-  const w3 = totalCount(week3) - totalCount(week2);
-  const w4 = totalCount(month) - totalCount(week3);
+  const previousMonthCount =
+    await getPreviousMonthActivityCount();
+  const bucketData = await getMonthlyActivityBuckets();
 
   return (
     <div className="min-h-screen transition-colors">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 py-10 space-y-14">
         <section className="text-center space-y-4">
-          <h1 className="text-5xl sm:text-5xl lg:text-7xl font-bold tracking-tight bg-clip-text text-transparent bg-linear-to-r from-[#50B78B] via-[#60C79B] to-[#70D7AB]
-">
+          <h1
+            className="text-5xl sm:text-5xl lg:text-7xl font-bold tracking-tight bg-clip-text text-transparent bg-linear-to-r from-[#50B78B] via-[#60C79B] to-[#70D7AB]
+"
+          >
             {config.org.name}
           </h1>
           <p className="max-w-2xl mx-auto text-sm sm:text-base text-zinc-600 dark:text-zinc-400">
@@ -45,11 +49,11 @@ export default async function Home() {
         <section className="grid gap-6 select-none sm:grid-cols-2 lg:grid-cols-3">
           <ActivityLineCard
             totalActivitiesLabel={totalCount(month)}
-            prev_month={totalCount(month2)}
-            week1={w1}
-            week2={w2}
-            week3={w3}
-            week4={w4}
+            prev_month={previousMonthCount}
+            week1={bucketData.w1}
+            week2={bucketData.w2}
+            week3={bucketData.w3}
+            week4={bucketData.w4}
           />
           <ActiveContributors data={month} />
           <ActivityTypes

--- a/components/Leaderboard/stats-card/activity-line-card.tsx
+++ b/components/Leaderboard/stats-card/activity-line-card.tsx
@@ -131,13 +131,25 @@ export function ActivityLineCard({
     [week1, week2, week3, week4, maxValue]
   );
 
-  const wowChange =
-    prev_month > 0
-      ? ((totalActivitiesLabel - prev_month) / prev_month) *
-        100
-      : 0;
-  const isUp = wowChange > 0;
-  const isDown = wowChange < 0;
+  let momChange: number | null = null;
+
+  if (prev_month > 0) {
+    momChange =
+      (totalActivitiesLabel - prev_month) / prev_month;
+  }
+
+  const isUp = momChange !== null && momChange > 0;
+  const isDown = momChange !== null && momChange < 0;
+
+  let changeLabel: string;
+
+  if (prev_month === 0) {
+    changeLabel = "New";
+  } else if (prev_month < 100) {
+    changeLabel = `${(momChange! + 1).toFixed(1)}×`;
+  } else {
+    changeLabel = `${(momChange! * 100).toFixed(1)}%`;
+  }
 
   return (
     <Card className="rounded-[20px] border-zinc-200 dark:border-white/10 bg-white dark:bg-linear-to-b dark:from-zinc-900 dark:via-zinc-900 dark:to-black shadow-xl shadow-[#edfff7] dark:shadow-black/50 overflow-hidden">
@@ -152,7 +164,13 @@ export function ActivityLineCard({
               {formattedTotal}
             </div>
             <CardDescription className="mt-2 text-sm font-medium">
-              Activity up significantly from last month
+              {prev_month === 0
+                ? "New activity tracking started"
+                : isUp
+                ? `Activity up from last month`
+                : isDown
+                ? `Activity down from last month`
+                : "Activity unchanged from last month"}
             </CardDescription>
           </div>
 
@@ -176,7 +194,7 @@ export function ActivityLineCard({
               {isDown && (
                 <ArrowDownRight className="mr-1 size-4" />
               )}
-              {Math.abs(wowChange).toFixed(1)}%
+              {changeLabel}
             </span>
           </div>
         </div>

--- a/components/PaginatedActivitySection.tsx
+++ b/components/PaginatedActivitySection.tsx
@@ -156,11 +156,7 @@ export function PaginatedActivitySection({
                       </span>
                     </span>
                     <span>•</span>
-                    <RelativeTime
-                      date={new Date(
-                        activity.occured_at ?? activity.closed_at
-                      )}
-                    />
+                    <RelativeTime date={new Date(activity.occured_at)} />
                   </div>
                 </div>
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,9 @@
 // lib/db.ts — temporary stub (no DB)
 
+import { UserEntry } from "@/scripts/generateLeaderboard";
 import fs from "fs";
 import path from "path";
+import { differenceInDays } from "date-fns";
 
 type ActivityItem = {
   slug: string;
@@ -10,7 +12,6 @@ type ActivityItem = {
   contributor_avatar_url: string | null;
   contributor_role: string | null;
   occured_at: string;
-  closed_at: string;
   title?: string | null;
   text?: string | null;
   link?: string | null;
@@ -24,6 +25,18 @@ export type ActivityGroup = {
   activities: ActivityItem[];
 };
 
+type RecentActivitiesJSON = {
+  updatedAt: number;
+  entries: UserEntry[];
+  groups: ActivityGroup[];
+};
+
+export type MonthBuckets = {
+  w1: number;
+  w2: number;
+  w3: number;
+  w4: number;
+};
 
 // Used by app/page.tsx
 // export async function getRecentActivitiesGroupedByType(valid: "week" | "month" | "year"): Promise<ActivityGroup[]> {
@@ -74,7 +87,7 @@ export type ActivityGroup = {
 // }
 
 export async function getRecentActivitiesGroupedByType(
-  valid: "week" | "2week" | "3week" | "month" | "2month" | "year"
+  valid: "week" | "month" | "2month" | "year"
 ): Promise<ActivityGroup[]> {
   const filePath = path.join(
     process.cwd(),
@@ -114,7 +127,6 @@ export async function getRecentActivitiesGroupedByType(
       contributor_avatar_url: user.avatar_url,
       contributor_role: user.role ?? null,
       occured_at: act.occured_at,
-      closed_at: act.occured_at,
       title: act.title ?? null,     // ✅ REAL title
       link: act.link ?? null,       // ✅ REAL GitHub link
       points: act.points ?? 0,
@@ -140,18 +152,68 @@ export async function getRecentActivitiesGroupedByType(
 // (Optional) stubs for other imports; add as you see “module not found” errors:
 
 export async function getUpdatedTime() {
-  // get last updated time from year.json (primary source for all period data)
+  // get last updated time from any of the JSON files
   const filePath = path.join(
     process.cwd(),
     "public",
     "leaderboard",
-    `year.json`
+    `week.json`
   );
   if (!fs.existsSync(filePath)) return null;
 
   const file = fs.readFileSync(filePath, "utf-8");
   const data = JSON.parse(file);
   return data.updatedAt ? new Date(data.updatedAt) : null;
+}
+
+export async function getMonthlyActivityBuckets(): Promise<MonthBuckets> {
+  const month = await getRecentActivitiesGroupedByType("month");
+  const activities = month.flatMap(g => g.activities);
+  const now = new Date();
+
+  const buckets: MonthBuckets = {
+    w1: 0,
+    w2: 0,
+    w3: 0,
+    w4: 0,
+  };
+
+  for (const activity of activities) {
+    const activityDate = new Date(activity.occured_at);
+    const daysAgo = differenceInDays(now, activityDate);
+
+    if (daysAgo < 0) continue;
+
+    if (daysAgo < 7) {
+      buckets.w1++;
+    } else if (daysAgo < 14) {
+      buckets.w2++;
+    } else if (daysAgo < 21) {
+      buckets.w3++;
+    } else if (daysAgo < 30) {
+      buckets.w4++;
+    }
+  }
+
+  return buckets;
+}
+
+export async function getPreviousMonthActivityCount(): Promise<number> {
+  const month = await getRecentActivitiesGroupedByType("2month");
+  const activities = month.flatMap(g => g.activities);
+  const now = new Date();
+
+  let count = 0;
+  for (const activity of activities) {
+    const activityDate = new Date(activity.occured_at);
+    const daysAgo = differenceInDays(now, activityDate);
+
+    if (daysAgo >= 30 && daysAgo < 60) {
+      count++;
+    }
+  }
+
+  return count;
 }
 
 export async function getLeaderboard() {

--- a/scripts/generateLeaderboard.ts
+++ b/scripts/generateLeaderboard.ts
@@ -262,8 +262,6 @@ async function generateYear() {
   console.log(`✅ Generated year.json (${entries.length} contributors)`);
 
   derivePeriod(yearData, 7, "week");
-  derivePeriod(yearData, 14, "2week");
-  derivePeriod(yearData, 21, "3week");
   derivePeriod(yearData, 30, "month");
   derivePeriod(yearData, 60, "2month");
 


### PR DESCRIPTION
## Description
This PR fixes incorrect month-over-month (MoM) statistics on the dashboard and improves how growth is presented to users.

Previously, the `prev_month` value was derived from the cumulative `2month` dataset, which included activities from both the current and previous months. This resulted in inaccurate comparisons and inflated growth values.

The logic now performs a true comparison between:
- **Current month**: last 0–30 days
- **Previous month**: 30–60 days ago

## Changes Made
- Added `getPreviousMonthActivityCount` in `lib/db.ts` to accurately count activities within the 30–60 day window.
- Updated the dashboard to use this corrected value for MoM comparisons.
- Improved growth display logic:
  - Uses **percentage (%)** when the previous month activity count is reasonably large.
  - Uses a **multiplier (×)** when the previous month count is small, avoiding misleading large percentages.
- Removed unused `2week` and `3week` data fetching from `page.tsx` to simplify and clean up the logic.

## Related Issue
Fixes #24

## Type of Change
- [x] Bug fix
- [x] Refactor

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added

## Screenshots

| Percentage Increase | Multiplier (Small Base) | No Increase / Neutral |
| :---: | :---: | :---: |
| ![](https://github.com/user-attachments/assets/2e0f355f-0df3-4a70-9da0-713bb854660d) | <img width="513" height="557" alt="image" src="https://github.com/user-attachments/assets/058f7dc4-e5f4-4ec1-8f45-9144d0713763" /> | ![](https://github.com/user-attachments/assets/283737f8-2221-4237-a6c3-70c76284c797) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity metrics now display month-over-month changes with dynamic indicators ("New," multiplicative, or percentage format).
  * Weekly activity breakdown for the current month.

* **Bug Fixes**
  * Activity timestamps now reliably use occurrence dates.

* **Chores**
  * Simplified activity period grouping; removed 2-week and 3-week variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->