### PR TITLE
fix: reflect actual rank while searching

### DIFF
--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -236,13 +236,10 @@ export default function LeaderboardView({
   // Rank is independent of search query and pagination
   // When role filtering is active, ranks are computed within the filtered subset
   const entryRanks = useMemo(() => {
-    // Filter by selectedRoles only when roles are selected (consistent with filteredEntries)
-    let entriesForRanking = entries;
-    if (selectedRoles.size > 0) {
-      entriesForRanking = entries.filter(
-        (entry) => entry.role && selectedRoles.has(entry.role)
-      );
-    }
+    // Always filter by selectedRoles to exclude hidden roles
+   const entriesForRanking = entries.filter(
+     (entry) => entry.role && selectedRoles.has(entry.role)
+   );
     
     // Sort by current sort criteria and calculate ranks
     const sorted = sortEntries(entriesForRanking, sortBy);


### PR DESCRIPTION
## Description
fixes an issue where contributor ranks change when searching or filtering the leaderboard
ranks are now preserved based on the original leaderboard order, so searching only filters the list without recalculating ranks

## Related Issue
Fixes #75

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
**Before**
<img width="959" height="476" alt="image" src="https://github.com/user-attachments/assets/187d5e51-1678-4dae-829a-8c63080c156e" />

**After**
<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/6c6c0cf2-8ae0-4691-946a-22c51477cf63" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stable, consistent rankings when filters or sorting change; sorting errors are caught and ranks fallback safely.

* **New Features**
  * Debounced search for smoother filtering and fewer rerenders.
  * Role-aware ranking that persists across pagination and reflects current filters.
  * Clickable contributor avatars linking to GitHub profiles.
  * Pagination defaults to show all with optional per-page limits; URL-driven sort/order/page updates without full reload.

* **UI**
  * Redesigned "No results" card, conditional Clear Filters action, top-three highlighting, and improved header/filter responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->