### PR TITLE
Fix regression: restore contributor name overflow handling

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -25,6 +25,8 @@ import {
   AlertCircle
 } from "lucide-react";
 
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
 type ActivityUIConfig = {
   icon: React.ReactNode;
   gradient: string;
@@ -219,8 +221,11 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
     ? Math.max(...sortedActivities.map(([, d]) => d.points))
     : 0;
 
+  const displayName = contributor.name || contributor.username;
+  const displayUsername = `@${contributor.username}`;
+
   return (
-    <div className="mx-auto px-4 py-8 max-w-7xl">
+    <div className="mx-auto px-4 py-8 max-w-7xl lg:max-w-[1300px]">
       <Button onClick={onBack} variant="outline" className="mb-6 hover:bg-primary cursor-pointer transition-colors">
         <ArrowLeft className="w-4 h-4 mr-2" />
         Back to People
@@ -251,9 +256,28 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
                   )}
                 </div>
 
-                <div className="text-center w-full">
-                  <h2 className="text-2xl font-bold mb-2">{contributor.name || contributor.username}</h2>
-                  <p className="text-muted-foreground mb-3 text-lg">@{contributor.username}</p>
+                 <div className="text-center w-full min-w-0 px-4">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <h2 className="text-2xl font-bold mb-2 truncate max-w-full min-w-0" aria-label={displayName}>
+                        {displayName}
+                      </h2>
+                    </TooltipTrigger>
+                    <TooltipContent sideOffset={6} side="top">
+                      {displayName}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <p className="text-muted-foreground mb-3 text-lg truncate max-w-full min-w-0" aria-label={displayUsername}>
+                        {displayUsername}
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent sideOffset={6} side="bottom">
+                      {displayUsername}
+                    </TooltipContent>
+                  </Tooltip>
                   <Badge variant="secondary" className="mb-6 bg-primary/10 text-primary font-semibold px-4 py-2">
                     {contributor.role}
                   </Badge>


### PR DESCRIPTION
## Description
This PR re-applies a previously merged fix for a UI layout regression on the **People → Contributor profile page**, where long contributor usernames were again overflowing outside the profile card due to a fork sync overwrite.

## Context
This is a follow-up PR to restore a fix that regressed after syncing a fork with `main`.

## Related Issue
Fixes #47 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots 
<img width="1882" height="905" alt="image" src="https://github.com/user-attachments/assets/d9e4c4e5-9d25-40a3-845a-0da358a67e13" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to contributor names and usernames that display full text on hover for better visibility of truncated content.
  * Enhanced layout responsiveness with improved width adjustments for large viewport displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->