### PR TITLE
fix: soften hover background for back button

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -226,7 +226,7 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
 
   return (
     <div className="mx-auto px-4 py-8 max-w-7xl lg:max-w-[1300px]">
-      <Button onClick={onBack} variant="outline" className="mb-6 hover:bg-primary cursor-pointer transition-colors">
+      <Button onClick={onBack} variant="outline" className="mb-6 hover:bg-primary/10 cursor-pointer transition-colors">
         <ArrowLeft className="w-4 h-4 mr-2" />
         Back to People
       </Button>


### PR DESCRIPTION
Fixes #64

This PR fixes the overly dark hover background on the “Back to People” button by softening the hover color.

The hover color is updated to better align with the existing design system
and maintain visual consistency across navigation buttons.
## Type of change 
- [ x ] Bug fix 
- [ ] Feature
- [ ] Refactor 
- [ ] Documentation
 
## Checklist
 - [ x ] Code follows project style
 - [ x ] Tested locally 
 - [ x ] No unnecessary files added 
 - [ x ] PR title is clear and descriptive 
 
 ## Screenshots (if applicable)  :  N/A – visual change is minor and scoped to hover state
