### PR TITLE
fix: modify Recent Contributions to be time sorted

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -205,7 +205,28 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
     }
   }
 
-  const recentContributions = contributor.activities?.slice(0, 15) || [];
+  const uniqueContributions = contributor.activities
+    ? (() => {
+        const seen = new Set<string>();
+        const unique: typeof contributor.activities = [];
+        
+        for (const activity of contributor.activities) {
+          const identifier = activity.link 
+            ? `${activity.type}-${activity.link}` 
+            : `${activity.type}-${activity.title}-${activity.occured_at}`;
+          
+          if (!seen.has(identifier)) {
+            seen.add(identifier);
+            unique.push(activity);
+          }
+        }
+        return unique;
+      })()
+    : [];
+
+  const recentContributions = uniqueContributions
+    .sort((a, b) => new Date(b.occured_at).getTime() - new Date(a.occured_at).getTime())
+    .slice(0, 15);
 
   const thisMonth = new Date();
   const monthlyActivity = recentActivity.filter(day => {


### PR DESCRIPTION
## Description
This PR fixes the ordering of the Recent Contributions section in a contributor's page
Previously, contributions were displayed grouped by category (PRs opened, PRs merged, issues opened) rather than by time

The updated logic first removes duplicate activities and then sorts all contributions chronologically based on `occured_at`, ensuring the most recent activity appears at the top regardless of contribution type
Only the latest 15 unique contributions are shown as previously shown

## Related Issue
Fixes #111 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
**Before**
<img width="1406" height="704" alt="image" src="https://github.com/user-attachments/assets/566b49db-b2ef-43e7-a558-f0a6ab098aa2" />

**After**
<img width="1405" height="671" alt="image" src="https://github.com/user-attachments/assets/9364e63e-2468-4a57-8d25-9d752045cffb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Recent Contributions section now removes duplicate activity entries to display only unique contributions. Users benefit from a cleaner and more accurate view of their contribution history. All existing monthly statistics and other profile functionality remain fully preserved and unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->