### PR TITLE
 Added concurrency control to prevent race conditions

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 */6 * * *" # every 6 hours
   workflow_dispatch:
 
+concurrency:
+  group: leaderboard-generation
+  cancel-in-progress: false
+
 permissions:
   contents: write
  


### PR DESCRIPTION
## Description
Adds concurrency control to the leaderboard generation workflow to prevent race conditions when manual (`workflow_dispatch`) and scheduled (cron) runs overlap. This ensures only one workflow instance runs at a time, preventing potential git conflicts and data corruption in leaderboard JSON files.

## Related Issue
Fixes #126 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Changes Made
- Added `concurrency` configuration with:
  - `group: leaderboard-generation` - Groups all workflow runs together
  - `cancel-in-progress: false` - Queues new runs instead of canceling active ones

## Checklist
- [x] Code follows project style
- [x] Tested locally (validated YAML syntax)
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Benefits
- ✅ Prevents race conditions between manual and scheduled runs
- ✅ Avoids git merge conflicts
- ✅ Ensures data integrity in leaderboard JSON files
- ✅ Zero performance impact - only adds queuing behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow concurrency configuration to prevent overlapping automation runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->