### PR TITLE
fix: footer layout responsiveness on tablet and smaller screens

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -56,12 +56,12 @@ export const Footer = async ({ config }: FooterProps) => {
               intuitive graphical interface
             </p>
 
-            <div className="flex items-center gap-4 pt-2">
+            <div className="flex items-center gap-2 sm:gap-4 pt-2 flex-wrap">
               <Hint label="Facebook" side="bottom">
                 <Link
                   href="https://www.facebook.com/CircuitVerse"
                   target="_blank"
-                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="Facebook"
                 >
                   <Image
@@ -69,6 +69,7 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="Facebook"
                     width={20}
                     height={20}
+                    className="w-5 h-5 sm:w-5 sm:h-5"
                   />
                 </Link>
               </Hint>
@@ -77,7 +78,7 @@ export const Footer = async ({ config }: FooterProps) => {
                 <Link
                   href="https://www.youtube.com/@circuitverse4457"
                   target="_blank"
-                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="YouTube"
                 >
                   <Image
@@ -85,6 +86,7 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="YouTube"
                     width={20}
                     height={20}
+                    className="w-5 h-5 sm:w-5 sm:h-5"
                   />
                 </Link>
               </Hint>
@@ -93,7 +95,7 @@ export const Footer = async ({ config }: FooterProps) => {
                 <Link
                   href="https://x.com/CircuitVerse"
                   target="_blank"
-                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 hover:bg-zinc-100 group/yt dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="Twitter"
                 >
                   <Image
@@ -101,7 +103,7 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="Twitter"
                     width={20}
                     height={20}
-                    className="dark:invert"
+                    className="w-5 h-5 sm:w-5 sm:h-5 dark:invert"
                   />
                 </Link>
               </Hint>
@@ -110,7 +112,7 @@ export const Footer = async ({ config }: FooterProps) => {
                 <Link
                   href="https://www.linkedin.com/company/circuitverse"
                   target="_blank"
-                  className="text-zinc-400 group/li hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 group/li hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="LinkedIn"
                 >
                   <Image
@@ -118,6 +120,7 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="LinkedIn"
                     width={20}
                     height={20}
+                    className="w-5 h-5 sm:w-5 sm:h-5"
                   />
                 </Link>
               </Hint>
@@ -126,7 +129,7 @@ export const Footer = async ({ config }: FooterProps) => {
                 <Link
                   href="https://github.com/CircuitVerse"
                   target="_blank"
-                  className="text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="GitHub"
                 >
                   <Image
@@ -134,7 +137,7 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="GitHub"
                     width={20}
                     height={20}
-                    className="dark:invert"
+                    className="w-5 h-5 sm:w-5 sm:h-5 dark:invert"
                   />
                 </Link>
               </Hint>
@@ -142,7 +145,7 @@ export const Footer = async ({ config }: FooterProps) => {
               <Hint label="Email">
                 <Link
                   href="mailto:support@circuitverse.org"
-                  className="text-zinc-400 group/em hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 rounded-full transition-all duration-200"
+                  className="text-zinc-400 group/em hover:bg-zinc-100 dark:hover:bg-zinc-800 p-2 sm:p-2 rounded-full transition-all duration-200"
                   aria-label="Email"
                 >
                   <Image
@@ -150,13 +153,14 @@ export const Footer = async ({ config }: FooterProps) => {
                     alt="Email"
                     width={20}
                     height={20}
+                    className="w-5 h-5 sm:w-5 sm:h-5"
                   />
                 </Link>
               </Hint>
             </div>
           </div>
 
-          <div className="col-span-1 col-start-3 md:col-span-2 md:col-start-5 lg:col-span-3 lg:col-start-7">
+          <div className="col-span-1 col-start-3 md:col-span-2 lg:col-span-3 lg:col-start-7">
             <h3 className="text-sm font-semibold uppercase tracking-wider text-zinc-900 dark:text-zinc-100 mb-3">
               Pages
             </h3>


### PR DESCRIPTION
## Description
fixes an issue where the footer did not span the full width on tablet and smaller screens, causing empty space on the right
the footer now responds correctly across all screen sizes without affecting the desktop layout

## Related Issue
Fixes #129 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
**mobile view**
<img width="549" height="798" alt="image" src="https://github.com/user-attachments/assets/e5a6c909-bd5f-4338-b331-136db2976699" />


**tablet view**
<img width="1321" height="764" alt="image" src="https://github.com/user-attachments/assets/77844317-778c-4a49-a030-1e8e13f03dfe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned footer grid for improved responsive behavior and visual hierarchy; sections repositioned and headers updated to uppercase with tighter tracking.
  * Social links condensed into a compact, wrap-capable row with consistent icon sizing and responsive padding.
  * Bottom bar made full-width with centered content on small screens and spaced alignment on larger viewports; copyright and timestamps retain dynamic data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->