### PR TITLE
fix: pagination scroll position on page change

### DIFF
--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -194,6 +194,7 @@ export default function LeaderboardView({
   const topRef = useRef<HTMLDivElement | null>(null);
   const scrollToLeaderboardTop = () => {
     if(typeof window === "undefined") return;
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     requestAnimationFrame(() => {
       if(!topRef.current) return;
@@ -204,7 +205,7 @@ export default function LeaderboardView({
       
       window.scrollTo({
         top: Math.max(absoluteTop - offset, 0),
-        behavior: "smooth",
+        behavior: prefersReducedMotion ? "auto" : "smooth",
       });
     });
   };

--- a/components/PaginatedActivitySection.tsx
+++ b/components/PaginatedActivitySection.tsx
@@ -39,6 +39,8 @@ export function PaginatedActivitySection({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const scrollSectionToTop = () => {
     if (typeof window === "undefined") return;
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
     requestAnimationFrame(() => {
       if (!containerRef.current) return;
 
@@ -49,7 +51,7 @@ export function PaginatedActivitySection({
 
       window.scrollTo({
         top: Math.max(absoluteTop - offset, 0),
-        behavior: "smooth",
+        behavior: prefersReducedMotion ? "auto" : "smooth",
       });
     });
   };


### PR DESCRIPTION
## Description
fixes an issue where changing pages using pagination did not scroll the view back to the top of the next page
the page content updated correctly, but the scroll position was preserved, requiring users to manually scroll up every time

this change ensures that whenever a new page is selected, the view automatically scrolls to the top, improving UX


## Related Issue
Fixes #136 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Leaderboard now automatically scrolls to the top when navigating pages or applying filters.
  * Activity sections now smoothly scroll into view when pagination changes, ensuring relevant content is immediately visible to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->