### PR TITLE
UI: move leaderboard controls below contributor count

### DIFF
--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -480,7 +480,7 @@ export default function LeaderboardView({
         <div className="flex-1 min-w-0">
           {/* Header */}
           <div className="mb-8">
-            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between mb-4">
               <div className="min-w-0">
                 <h1 className="text-4xl text-[#50B78B] font-bold mb-2">
                   {periodLabels[period]} Leaderboard
@@ -497,13 +497,13 @@ export default function LeaderboardView({
                   w-full
                   md:w-auto md:ml-auto
                   flex flex-col
-                  md:items-end
+                  md:flex-row md:items-center
                   lg:flex-row lg:items-center
                   gap-2
                 "
               >
                 {/* Search bar - full width on mobile */}
-                <div className="relative w-full md:w-[16rem]">
+                <div className="relative w-full md:w-[20rem] lg:w-[16rem]">
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
                     type="text"


### PR DESCRIPTION
## Description
This PR improves the **Leaderboard header layout** by moving all interactive controls (Search, Clear, Filter, etc.) to a **separate line below the contributor count**.

Previously, the controls appeared crowded near the heading and contributor count on certain screen sizes. This update improves visual consistency across viewports.

## Related Issue
Fixes #140 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
#### Before

<img width="1920" height="1020" alt="Leaderboard - CircuitVerse - Google Chrome 06-01-2026 21_32_04" src="https://github.com/user-attachments/assets/97f40f82-9d7e-4feb-a71b-23a12504078e" />

#### After
Controls are clearly separated and placed on the next line, improving readability and layout consistency.

<img width="1911" height="972" alt="image" src="https://github.com/user-attachments/assets/10c6132c-9fb8-4eba-a4c5-ee3d1003efa4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the leaderboard interface across tablet and larger screens, with optimized alignment and sizing of search and filter controls for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->