### PR TITLE
fix: inconsistent updated timestamp between People page and footer

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -152,18 +152,26 @@ export async function getRecentActivitiesGroupedByType(
 // (Optional) stubs for other imports; add as you see “module not found” errors:
 
 export async function getUpdatedTime() {
-  // get last updated time from any of the JSON files
-  const filePath = path.join(
-    process.cwd(),
-    "public",
-    "leaderboard",
-    `week.json`
+  const publicPath = path.join(process.cwd(), "public", "leaderboard");
+  if(!fs.existsSync(publicPath)) return null;
+  const files = fs.readdirSync(publicPath).filter(
+    (file) => file.endsWith(".json") && file !== "recent-activities.json"
   );
-  if (!fs.existsSync(filePath)) return null;
 
-  const file = fs.readFileSync(filePath, "utf-8");
-  const data = JSON.parse(file);
-  return data.updatedAt ? new Date(data.updatedAt) : null;
+  let latestUpdatedAt = 0;
+  for(const file of files){
+    try{
+      const filePath = path.join(publicPath, file);
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      if (data.updatedAt && data.updatedAt > latestUpdatedAt) {
+        latestUpdatedAt = data.updatedAt;
+      }
+    } catch (error) {
+      // Skip files that can't be parsed
+      continue;
+    }
+  }
+  return latestUpdatedAt > 0 ? new Date(latestUpdatedAt) : null;
 }
 
 export async function getMonthlyActivityBuckets(): Promise<MonthBuckets> {


### PR DESCRIPTION
## Description
this PR fixes the mismatch in the “updated” timestamp shown on the people page and in the footer
previously, the footer computed the update time using a single JSON file, while the people page derived it by aggregating multiple JSON files, this difference caused inconsistent timestamps to be displayed across the UI

## Related Issue
Fixes #144 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
**people's page**
<img width="959" height="233" alt="image" src="https://github.com/user-attachments/assets/22b4475d-ac3e-4879-bf2d-dddb4978d95f" />


**footer**
<img width="956" height="236" alt="image" src="https://github.com/user-attachments/assets/0280d038-43ce-40c9-9624-559ac2ea58ba" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard update time tracking to accurately reflect the most recent data from all leaderboard sources with enhanced error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->