### PR TITLE
fix: handle invalid leaderboard period with not found page

### DIFF
--- a/app/leaderboard/[period]/page.tsx
+++ b/app/leaderboard/[period]/page.tsx
@@ -43,7 +43,7 @@ export default async function Page({
   params: Promise<{ period: "week" | "month" | "year" }>;
 }) {
   const { period } = await params;
-  // navigate to not found page, if time periods are othen week/month/year
+  // navigate to not found page, if time periods are other than week/month/year
   if (!isValidPeriod(period)) {
     notFound();
   }


### PR DESCRIPTION
## Description
Navigating to invalid leaderboard periods (e.g., /leaderboard/daily, /leaderboard/invalid) causes a 500 Internal Server Error instead of showing the 404 not-found page.

## Related Issue
Fixes #146 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable
## Before

https://github.com/user-attachments/assets/031885a3-07c8-49c5-9227-5096518b7e2e

## After

https://github.com/user-attachments/assets/5270761c-8dfb-4ac9-b84e-671a8226d3fd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The leaderboard now validates the selected time period and shows a 404 page for invalid or unsupported period values, preventing broken or confusing views and improving navigation and overall user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->