### PR TITLE
Fix mobile date wrapping in Recent Contributions

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -491,7 +491,7 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
                                 <span className={`font-medium px-2 py-1 rounded-full ${config.bgColor} ${config.textColor}`}>
                                   {activity.type}
                                 </span>
-                                <span className="flex items-center gap-1">
+                                <span className="flex items-center gap-1 whitespace-nowrap shrink-0">
                                   <Calendar className="w-3 h-3" />
                                   {daysAgo === 0 ? 'Today' : daysAgo === 1 ? 'Yesterday' : `${daysAgo} days ago`}
                                 </span>


### PR DESCRIPTION
## Description
This PR fixes a mobile UI issue where the date text (e.g. 7 days ago ) in the Recent Contributions section wrapped into multiple lines on small screen widths. The issue was most visible on mobile devices, causing misalignment in contribution tiles.

## Related Issue
Fixes #148 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots
<img width="1918" height="970" alt="image" src="https://github.com/user-attachments/assets/9fd20fbf-49c8-4363-9868-c7a41452616e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping in the Recent Contributions section to ensure day labels display properly without breaking across multiple lines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->