### PR TITLE
feat(leaderboard): persist layout across period changes

### DIFF
--- a/app/leaderboard/[period]/page.tsx
+++ b/app/leaderboard/[period]/page.tsx
@@ -40,10 +40,15 @@ function isValidPeriod(period: string): period is "week" | "month" | "year" {
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ period: "week" | "month" | "year" }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const { period } = await params;
+  const query = await searchParams;
+  const isGridView = query.v === "grid";
+  
   // navigate to not found page, if time periods are other than week/month/year
   if (!isValidPeriod(period)) {
     notFound();
@@ -64,7 +69,7 @@ export default async function Page({
   const data: LeaderboardJSON = JSON.parse(file);
 
   return (
-    <Suspense fallback={<LeaderboardSkeleton count={10} variant="list" />}>
+    <Suspense fallback={<LeaderboardSkeleton count={10} variant={isGridView ? "grid" : "list"} />}>
       <LeaderboardView
         entries={data.entries}
         period={period}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -17,6 +17,7 @@ import { LeaderboardSkeleton } from "@/components/Leaderboard/LeaderboardSkeleto
 function LeaderboardIndexPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isGridView = searchParams?.get("v") === "grid";
 
   useEffect(() => {
     const params = searchParams?.toString();
@@ -24,7 +25,7 @@ function LeaderboardIndexPageContent() {
     router.replace(target);
   }, [router, searchParams]);
 
-  return <LeaderboardSkeleton count={10} variant="list" />;
+  return <LeaderboardSkeleton count={10} variant={isGridView ? "grid" : "list"} />;
 }
 
 export default function LeaderboardIndexPage() {

--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -191,12 +191,12 @@ export default function LeaderboardView({
   const pathname = usePathname();
   
   const [viewMode, setViewMode] = useState<"grid" | "list">(() => {
-    const v = searchParams.get("view");
+    const v = searchParams.get("v");
     return v === "grid" ? "grid" : "list";
   });
 
   useEffect(() => {
-    const v = searchParams.get("view");
+    const v = searchParams.get("v");
     setViewMode(v === "grid" ? "grid" : "list");
   }, [searchParams]);
   const topRef = useRef<HTMLDivElement | null>(null);
@@ -222,9 +222,9 @@ export default function LeaderboardView({
     setViewMode(mode);
     const params = new URLSearchParams(searchParams.toString());
     if (mode === "list") {
-      params.delete("view");
+      params.delete("v");
     } else {
-      params.set("view", mode);
+      params.set("v", mode);
     }
     if (typeof window !== "undefined") {
       window.history.replaceState(null, "", `${pathname}?${params.toString()}`);


### PR DESCRIPTION
## Description

Persists the selected leaderboard layout (grid/list) across period changes by storing it in the URL as `?view=grid`. When a user switches between Weekly/Monthly/Yearly, the layout now remains unchanged. URLs stay clean by omitting the param when in list mode (default).

Also preserves all existing query params when redirecting from `/leaderboard` to `/leaderboard/month`.

## Related Issue

Fixes #135 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Changes Made

### `components/Leaderboard/LeaderboardView.tsx`
- Initialize `viewMode` from `searchParams` on mount and sync on changes via `useEffect`
- Update `handleViewModeChange()` to persist layout to URL:
  - `grid` → sets `?view=grid`
  - `list` → removes `view` param (clean URL)
- Uses `window.history.replaceState` to avoid navigation reloads

### `app/leaderboard/page.tsx`
- Preserve all query params (including `view`) when redirecting to `/leaderboard/month`

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

##Screeshots/GIFs

https://github.com/user-attachments/assets/76eac37b-ba90-4f4f-9b3c-ae66e70bcffe




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View mode toggle (grid/list) is persisted in the URL and kept in sync with the UI.
  * Visiting the leaderboard now redirects to the monthly view while preserving all query parameters.

* **Improvements**
  * Loading skeletons now match the selected view (grid or list) for smoother, more consistent transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->