### PR TITLE
fix: incorrect activity types count in this month’s activity

### DIFF
--- a/components/people/ContributorDetail.tsx
+++ b/components/people/ContributorDetail.tsx
@@ -239,6 +239,18 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
 
   const monthlyPoints = monthlyActivity.reduce((sum, day) => sum + day.points, 0);
   const monthlyDays = monthlyActivity.length;
+  const monthlyActivityTypes = new Set<string>();
+  if(contributor.activities){
+    const currentMonth = thisMonth.getMonth();
+    const currentYear = thisMonth.getFullYear();
+    for(const activity of contributor.activities){
+      const activityDate = new Date(activity.occured_at);
+      if(activityDate.getMonth() === currentMonth && activityDate.getFullYear() === currentYear){
+        monthlyActivityTypes.add(activity.type);
+      }
+    }
+  }
+  const monthlyActivityTypesCount = monthlyActivityTypes.size;
   const maxPoints =
   sortedActivities.length > 0
     ? Math.max(...sortedActivities.map(([, d]) => d.points))
@@ -369,7 +381,7 @@ export function ContributorDetail({ contributor, onBack }: ContributorDetailProp
                   <div className="text-sm text-muted-foreground">Daily Average</div>
                 </div>
                 <div className="text-center p-4 bg-background/50 rounded-lg">
-                  <div className="text-2xl font-bold text-primary">{sortedActivities.length}</div>
+                  <div className="text-2xl font-bold text-primary">{monthlyActivityTypesCount}</div>
                   <div className="text-sm text-muted-foreground">Activity Types</div>
                 </div>
               </div>


### PR DESCRIPTION
## Description
this PR fixes an issue where the activity types count in the this month’s activity section was showing a value even when the contributor had no activity in the current month
the monthly activity summary now correctly reflects only current month data

## Related Issue
Fixes #157 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

**before**
<img width="1919" height="946" alt="Screenshot 2026-01-08 183400" src="https://github.com/user-attachments/assets/7a4315fd-eaaf-4f86-8393-826eb7c7adee" />


**after**
<img width="1918" height="889" alt="image" src="https://github.com/user-attachments/assets/2d444ef7-1341-46e8-9727-41c3a6b86c43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Updated the "This Month's Activity" metric on contributor profiles to display the count of unique activity types performed during the month, rather than total activity count. This provides a more meaningful measure of contributor engagement diversity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->