### PR TITLE
footer layout issue fix

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -35,7 +35,7 @@ export const Footer = async ({ config }: FooterProps) => {
                 href="https://circuitverse.org/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2"
+                className="inline-flex w-fit items-center gap-2"
               >
                 <Image
                   src={config.org.logo_url}
@@ -169,7 +169,7 @@ export const Footer = async ({ config }: FooterProps) => {
               <li>
                 <Link
                   href="/"
-                  className="group flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
+                  className="group inline-flex w-fit items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
                 >
                   <span className="text-zinc-400 group-hover:text-[#50B78B] transition-colors">
                     <HomeIcon className="h-4 w-4" />
@@ -182,7 +182,7 @@ export const Footer = async ({ config }: FooterProps) => {
               <li>
                 <Link
                   href="/leaderboard"
-                  className="group flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
+                  className="group inline-flex w-fit items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
                 >
                   <span className="text-zinc-400 group-hover:text-[#50B78B] transition-colors">
                     <Trophy className="h-4 w-4" />
@@ -195,7 +195,7 @@ export const Footer = async ({ config }: FooterProps) => {
               <li>
                 <Link
                   href="/people"
-                  className="group flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
+                  className="group inline-flex w-fit items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
                 >
                   <span className="text-zinc-400 group-hover:text-[#50B78B] transition-colors">
                     <Users className="h-4 w-4" />
@@ -208,7 +208,7 @@ export const Footer = async ({ config }: FooterProps) => {
               <li>
                 <Link
                   href="/releases"
-                  className="group flex items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
+                  className="group inline-flex w-fit items-center gap-2 text-sm text-zinc-600 dark:text-zinc-400 hover:text-[#50B78B] transition-colors"
                 >
                   <span className="text-zinc-400 group-hover:text-[#50B78B] transition-colors">
                     <Tag className="h-4 w-4" />


### PR DESCRIPTION
## Description
Fixed oversized clickable areas for footer navigation links that extended far beyond the visible link text. The clickable regions previously spanned nearly the entire container width (~481px), making it possible to accidentally trigger links when clicking in empty space. Now the clickable areas are properly constrained to only the actual link content.

**Changes made:**
- Updated the CircuitVerse logo link to use `inline-flex w-fit`
- Updated all navigation links (Home, Leaderboard, People, Releases) to use `inline-flex w-fit` instead of `flex`
- Clickable areas now properly fit the content (e.g., Home link: ~82px instead of ~481px)

## Related Issue
Fixes #191 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

<img width="738" height="485" alt="Screenshot 2026-01-10 200507" src="https://github.com/user-attachments/assets/ce07804f-d729-4d5b-b5f8-7ddfb4d76450" />

<img width="844" height="375" alt="Screenshot 2026-01-10 200520" src="https://github.com/user-attachments/assets/6757c9e4-8483-405e-8f65-e9a3f02b2ac7" />


### Technical Details:
Changed from:
```tsx
className="flex items-center gap-2"
```

to:
```tsx
className="inline-flex w-fit items-center gap-2"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer navigation item layout with improved alignment and spacing properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->