### PR TITLE
feat: set leaderboard default to show top 50 contributors instead of all

### DIFF
--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -428,7 +428,7 @@ export default function LeaderboardView({
   const updatePageSize = (newPageSize: number | "all") => {
     const params = new URLSearchParams(searchParams.toString());
     if (newPageSize === "all" || newPageSize === Infinity) {
-      params.delete("limit");
+      params.set("limit", "all");
       setPageSize(Infinity);
     } else {
       params.set("limit", newPageSize.toString());


### PR DESCRIPTION
## Description

Changed the default leaderboard view to show the top 50 contributors instead of all contributors.  
Users can still select "Show All" or other page size options (10, 25, 100) if they wish.  
This improves readability, reduces clutter, and speeds up initial page load, especially on mobile.

---

## Related Issue

Fixes #156

---

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation

---

## Changes Made

- **Updated `components/Leaderboard/LeaderboardView.tsx`**
    - Default page size is now 50 instead of "Show All"
    - All other page size options ("Show All", 10, 25, 100) remain available for user selection

---

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

---

## Screenshots/GIFs


https://github.com/user-attachments/assets/6f88441c-bddf-4384-9bd1-8279f88cfb20




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Leaderboard now defaults to showing the top 50 entries for improved performance and readability.
  * Selecting a numeric page size continues to work as before; "all" still shows the complete leaderboard.
  * Choosing "all" now explicitly sets that option in the URL for clearer bookmarking/sharing.

* **Bug Fixes**
  * Invalid or missing page-size values now fall back to the 50-entry default instead of showing everything.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->