### PR TITLE
fix: leaderboard card ring alignment for consistent sizing in tab view

### DIFF
--- a/components/Leaderboard/LeaderboardCard.tsx
+++ b/components/Leaderboard/LeaderboardCard.tsx
@@ -172,7 +172,7 @@ export function LeaderboardCard({
       )}>
         <Card
           className={cn(
-            "relative z-10 overflow-hidden transition-all duration-500 border-2",
+            "relative z-10 overflow-hidden transition-all duration-500 border-2 h-full flex flex-col",
             styles.border,
             "hover:shadow-2xl hover:-translate-y-1"
           )}

--- a/components/Leaderboard/LeaderboardView.tsx
+++ b/components/Leaderboard/LeaderboardView.tsx
@@ -827,8 +827,8 @@ export default function LeaderboardView({
           ) : (
             <div className={cn(
               viewMode === "grid"
-                ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6"
-                : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4 lg:gap-0 lg:space-y-4 lg:block"
+                ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6 items-stretch"
+                : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4 lg:gap-0 lg:space-y-4 lg:block items-stretch"
             )}>
               {paginatedEntries.map((entry, index) => {
                 // Use the pre-computed rank from entryRanks, which is based on full sorted list


### PR DESCRIPTION
## Description

Fixed an issue where the animated border ring (gold, silver, bronze) for top leaderboard cards did not align with the card size in tablet view. Previously, cards with less content appeared shorter, causing a visible gap between the card and its background ring. Now, all cards in a row have equal height, ensuring the ring always matches the card size for a clean and consistent look.

## Related Issue

Fixes #195 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Changes Made

- Updated the leaderboard grid container to use `items-stretch` for robust card height alignment.
- Ensured each leaderboard card uses `h-full flex flex-col` so the card and its animated border always match in height.
- No breaking changes; layout is now more robust and visually consistent across all screen sizes.

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots

## Before
<img width="1244" height="941" alt="image" src="https://github.com/user-attachments/assets/273839ef-3775-4680-bb0f-934f8f185b74" />

## After
<img width="1264" height="922" alt="image" src="https://github.com/user-attachments/assets/d3ff9754-2080-4afc-b939-c3f1d2888670" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted leaderboard card sizing and vertical layout so each card fills available height and stacks content vertically for more balanced spacing.
  * Improved grid item alignment across leaderboard views to ensure rows and cards align consistently, enhancing visual uniformity and reducing uneven gaps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->