### PR TITLE
fix:  Prevent unwanted horizontal scroll on mobile by adding overflow…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -140,6 +140,10 @@ body::selection {
   }
   body {
     @apply bg-background text-foreground;
+    overflow-x: hidden;
+  }
+  html {
+    overflow-x: hidden;
   }
 }
 


### PR DESCRIPTION
## Description

Added a global CSS fix to prevent unwanted horizontal (X-axis) scrolling on mobile devices.  
By setting `overflow-x: hidden` on both `html` and `body` in `globals.css`, the page no longer allows accidental horizontal scrolling when content overflows, improving the mobile user experience. This ensures the layout remains within the viewport width on all devices.

Fixes #199 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Changes Made

- Modified `app/globals.css`  
    - Added `overflow-x: hidden` to both `html` and `body` selectors  
    - Prevents unwanted horizontal scrolling on all pages, especially on mobile devices

## Checklist

- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive
## Screenshots/ GIFs

https://github.com/user-attachments/assets/6c6dc695-5936-4133-a2de-9f2600f5bf91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Disabled horizontal scrolling across the page for improved layout stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->