### PR TITLE
feat: make Issues, Open PRs, and Merged PR stats clickable on repo cards

### DIFF
--- a/components/home-dashboard.tsx
+++ b/components/home-dashboard.tsx
@@ -386,24 +386,42 @@ function RepoCard({ repo }: { repo: RepoStats }) {
       {/* Metrics Section */}
       <div className="px-5 pb-5 sm:px-6 sm:pb-6 pt-0">
         <div className="grid grid-cols-3 gap-2 rounded-xl bg-zinc-50 dark:bg-zinc-800/40 p-2 border border-zinc-100 dark:border-zinc-800/60">
-          <MetricFlowItem
-            icon={<CircleDot className="h-4 w-4 sm:h-5 sm:w-5" />}
-            count={repo.current.issue_created}
-            label="Issues"
-            variant="neutral"
-          />
-          <MetricFlowItem
-            icon={<GitPullRequest className="h-4 w-4 sm:h-5 sm:w-5" />}
-            count={repo.current.pr_opened}
-            label="Open"
-            variant="active"
-          />
-          <MetricFlowItem
-            icon={<GitMerge className="h-4 w-4 sm:h-5 sm:w-5" />}
-            count={repo.current.pr_merged}
-            label="Merged"
-            variant="success"
-          />
+          <Link
+            href={`${repo.html_url}/issues`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <MetricFlowItem
+              icon={<CircleDot className="h-4 w-4 sm:h-5 sm:w-5" />}
+              count={repo.current.issue_created}
+              label="Issues"
+              variant="neutral"
+            />
+          </Link>
+          <Link
+            href={`${repo.html_url}/pulls`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <MetricFlowItem
+              icon={<GitPullRequest className="h-4 w-4 sm:h-5 sm:w-5" />}
+              count={repo.current.pr_opened}
+              label="Open"
+              variant="active"
+            />
+          </Link>
+          <Link
+            href={`${repo.html_url}/pulls?q=is%3Apr+is%3Amerged`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <MetricFlowItem
+              icon={<GitMerge className="h-4 w-4 sm:h-5 sm:w-5" />}
+              count={repo.current.pr_merged}
+              label="Merged"
+              variant="success"
+            />
+          </Link>
         </div>
       </div>
     </div>
@@ -438,7 +456,7 @@ function MetricFlowItem({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center p-2 sm:p-3 rounded-lg transition-colors cursor-default",
+        "flex flex-col items-center justify-center p-2 sm:p-3 rounded-lg transition-colors cursor-pointer",
         styles.bg
       )}
     >


### PR DESCRIPTION
## Description

This PR enhances the **Community Dashboard** by making the **Issues**, **Open PRs**, and **Merged PRs** counters on each repository card interactive.

Previously, these values were displayed only as static numbers, requiring users to manually navigate to GitHub to view the corresponding issues or pull requests. With this change, clicking on any of these stats now redirects users directly to the appropriate GitHub page for that repository, filtered by issues, open pull requests, or merged pull requests.


## Related Issue
Fixes #203 

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots 

https://github.com/user-attachments/assets/ed3b9700-ccbf-421a-a000-99e3b08c48c1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository metrics (issues, pull requests, and merged pull requests counts) are now clickable, allowing quick navigation to their respective pages in a new tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->