### PR TITLE
fix: ensure repository titles open in a new tab #205

### DIFF
--- a/components/home-dashboard.tsx
+++ b/components/home-dashboard.tsx
@@ -361,7 +361,13 @@ function RepoCard({ repo }: { repo: RepoStats }) {
             {/* Added min-w-0 to allow truncation inside flex */}
             <div className="min-w-0 flex-1">
               <div className="text-base sm:text-lg font-bold text-zinc-900 dark:text-zinc-100 hover:text-[#50B78B] dark:hover:text-[#50B78B] transition-colors truncate">
-                <Link href={repo.html_url}>{repo.name}</Link>
+                <Link 
+                  href={repo.html_url} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                            >
+                      {repo.name}
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Description
Currently, clicking on a repository name in the overview section redirects the user within the same tab, causing them to lose their place on the dashboard. This PR adds target="_blank" and rel="noopener noreferrer" to the main repository title link in the RepoCard component.

Changes
Modified home-dashboard.tsx to update the Link component for repository titles.

Ensured security compliance by adding rel="noopener noreferrer".

Verification
Verified locally on macOS (Brave).

Confirmed that clicking the title opens a new tab and preserves the dashboard state.

Fixes #205
## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated repository name links to open in a new tab when clicked, improving navigation flow while maintaining security standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->