### PR TITLE
Fix/leaderboard light theme 229

### DIFF
--- a/components/Leaderboard/LeaderboardSkeleton.tsx
+++ b/components/Leaderboard/LeaderboardSkeleton.tsx
@@ -12,7 +12,7 @@ function SkeletonPulse({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "animate-pulse rounded-md bg-gray-200 dark:bg-muted/60",
+        "animate-pulse rounded-md bg-gray-300 dark:bg-muted/60",
         className
       )}
     />


### PR DESCRIPTION
## Description
Improved contrast of leaderboard skeleton loaders in light theme so that loading placeholders are clearly visible and no longer appear as a blank card.

## Related Issue
Fixes #229 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
<img width="1919" height="916" alt="Screenshot 2026-01-22 091021" src="https://github.com/user-attachments/assets/3e330ee3-7ee9-4fa2-87aa-a67dd9d0ad3d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual appearance of the leaderboard loading indicator in light mode for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->