### PR TITLE
fix navbar: activate mobile navbar earlier to prevent overlap

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -37,7 +37,7 @@ const Navbar = ({ config }: NavbarProps) => {
     <>
       {/* Desktop Navbar */}
       <header className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[95%] max-w-5xl rounded-full border border-zinc-200/60 dark:border-white/10 bg-white/40 dark:bg-zinc-950/40 backdrop-blur-md shadow-md">
-              <div className="px-4 h-14 flex items-center justify-between">
+        <div className="px-4 h-14 flex items-center justify-between">          
           {/* Logo */}
           <Link href="/" className="flex items-center gap-3">
             <Image
@@ -51,8 +51,8 @@ const Navbar = ({ config }: NavbarProps) => {
           </Link>
 
           {/* Nav Links */}
-          <nav className="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border bg-white/30 dark:bg-zinc-950/30 backdrop-blur-md shadow-sm">
-                      {navItems.map((item) => {
+          <nav className="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border bg-white/30 dark:bg-zinc-950/30 backdrop-blur-md shadow-sm">
+            {navItems.map((item) => {
               const active = isActive(item.href);
 
               return (
@@ -107,11 +107,10 @@ const Navbar = ({ config }: NavbarProps) => {
 
       {/* Mobile Navbar */}
       <nav
-        className={`md:hidden fixed left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-in-out ${
+        className={`lg:hidden fixed left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ease-in-out ${
         scrollDirection === "down" ? "-bottom-40 opacity-0 pointer-events-none" : "bottom-4 opacity-100"
         }`}
-       >
-
+      >
         <div className="flex items-center gap-1 rounded-full border border-zinc-200 dark:border-white/10 bg-background/90 backdrop-blur-xl shadow-xl p-1">
           {navItems.map((item) => {
             const Icon = item.icon;


### PR DESCRIPTION
## Description
On the Leaderboard page, the desktop navbar overlaps with the CircuitVerse name on medium screen sizes due to the mobile navbar activating too late.

---

## What this PR does
- Activates the mobile navbar earlier by switching the breakpoint from `md` to `lg`
- Prevents overlap between the name and navbar items
- Keeps existing layout, styles, and logic unchanged

## Related Issue
Fixes #233 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

### Before

<img width="1338" height="570" alt="Screenshot 2026-01-23 000019" src="https://github.com/user-attachments/assets/2726861c-94bc-43e6-bcca-58c7784b5462" />


### After

<img width="1218" height="896" alt="image" src="https://github.com/user-attachments/assets/8caf5fe4-87b6-4cae-b302-8a9138bf1beb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted navigation breakpoints to optimize the display of navigation elements across different screen sizes, particularly improving responsiveness on medium-sized viewports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->