### PR TITLE
fix: prevent layout shift when toggling theme dropdown

### DIFF
--- a/app/ThemeSelector.tsx
+++ b/app/ThemeSelector.tsx
@@ -23,7 +23,7 @@ export default function ThemeSelector() {
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon">
           <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />


### PR DESCRIPTION
## Related Issue
Fixes #235 

### Summary
Clicking the theme selector on desktop caused the page layout to shift horizontally due to body scroll locking applied by the theme dropdown. Disables modal behavior on the theme dropdown (modal={false})
Prevents body scroll locking and layout width changes.
Ensures smooth, stable UI when toggling themes on desktop.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots

https://github.com/user-attachments/assets/5d6e18b8-813f-425e-94d8-fad6443169e6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted theme selector dropdown behavior to enhance usability and interaction flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->