### PR TITLE
improve leaderboard skeleton loader visibility in light theme

### DIFF
--- a/components/Leaderboard/LeaderboardSkeleton.tsx
+++ b/components/Leaderboard/LeaderboardSkeleton.tsx
@@ -12,7 +12,9 @@ function SkeletonPulse({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "animate-pulse rounded-md bg-muted/60",
+        // Use a more visible skeleton color in both themes
+        "animate-pulse rounded-md",
+        "bg-zinc-200 dark:bg-zinc-700",
         className
       )}
     />


### PR DESCRIPTION
## Description

Improved the visibility of the leaderboard skeleton loader in both light and dark themes. Previously, the skeleton placeholder elements (lines, circles, etc.) were barely visible or blended into the card background in light mode, making the loading state look like a blank card. Now, the skeleton uses higher-contrast backgrounds (`bg-zinc-200` for light, `bg-zinc-700` for dark) to ensure all placeholder elements are clearly visible.

## Related Issue

Fixes #229 
## Type of change

- Bug fix

## Changes Made

- Updated `components/Leaderboard/LeaderboardSkeleton.tsx`
    - Changed the skeleton placeholder background from `bg-muted/60` to `bg-zinc-200 dark:bg-zinc-700` for better contrast in all themes

## Checklist

- [X] Code follows project style
- [X]  Tested locally in both light and dark themes
- [X]  No unnecessary files added
- [X]  PR title is clear and descriptive

## Screenshots/GIFs
<img width="1903" height="972" alt="2026-01-24-004105_hyprshot" src="https://github.com/user-attachments/assets/555b2171-e53b-4e2b-b73c-ab0514e329f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced skeleton loading states with improved theme-aware color handling for better visual consistency between light and dark modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->