### PR TITLE
fix(ui): adjust height

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -31,7 +31,7 @@ export default async function AnalyticsPage() {
           <h2 className="text-2xl font-semibold text-zinc-800 dark:text-zinc-200">
             Review Dashboard
           </h2>
-          <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 items-stretch">
             <Suspense fallback={<ReviewMetricsSkeleton />}>
               <ReviewMetricsCard />
             </Suspense>

--- a/components/Analytics/ActiveReviewersCard.tsx
+++ b/components/Analytics/ActiveReviewersCard.tsx
@@ -99,10 +99,10 @@ export function ActiveReviewersCard() {
     );
   }
 
-  const topReviewers = data.reviewMetrics.topReviewers.slice(0, 5);
+  const topReviewers = data.reviewMetrics.topReviewers.slice(0, 6);
 
   return (
-    <Card className="col-span-2">
+    <Card className="col-span-2 h-full flex flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Users className="h-5 w-5" />

--- a/components/Analytics/ReviewDistributionChart.tsx
+++ b/components/Analytics/ReviewDistributionChart.tsx
@@ -145,7 +145,7 @@ export function ReviewDistributionChart() {
   };
 
   return (
-    <Card className="col-span-2">
+    <Card className="col-span-2 h-full flex flex-col">
       <CardHeader className="pb-4">
         <CardTitle className="text-lg">Review State Distribution</CardTitle>
         <CardDescription className="text-sm">


### PR DESCRIPTION
## Description
Adjust the height ReviewDistributionCard and ActiveReviewersCard to look the same.
Increase the count of top reviewers in the ActiveReviewersCard from 5 to 6 match the height.

## Related Issue
Fixes #239 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

### Before
<img width="1330" height="551" alt="Screenshot 2026-01-25 at 12 07 38 AM" src="https://github.com/user-attachments/assets/72e7643e-7c97-48ee-bfa2-3520d436f0e6" />

### After
<img width="1267" height="559" alt="Screenshot 2026-01-25 at 12 04 33 AM" src="https://github.com/user-attachments/assets/c8e9a02b-3d25-4d81-9439-cc9ddbd9ce98" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & Layout**
  * Improved Analytics dashboard grid alignment and spacing for better visual consistency.
  * Enhanced Active Reviewers card to display six reviewers instead of five.
  * Optimized card container styling across the Analytics section for improved layout presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->