### PR TITLE
fix(ui): adjust height

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -35,7 +35,7 @@ export default async function AnalyticsPage() {
             <Suspense fallback={<ReviewMetricsSkeleton />}>
               <ReviewMetricsCard />
             </Suspense>
-            <div className="col-span-full lg:col-span-2">
+            <div className="col-span-full lg:col-span-2 items-stretch">
               <Suspense fallback={<ActiveReviewersSkeleton />}>
                 <ActiveReviewersCard />
               </Suspense>

--- a/components/Analytics/ActiveReviewersCard.tsx
+++ b/components/Analytics/ActiveReviewersCard.tsx
@@ -99,10 +99,10 @@ export function ActiveReviewersCard() {
     );
   }
 
-  const topReviewers = data.reviewMetrics.topReviewers.slice(0, 5);
+  const topReviewers = data.reviewMetrics.topReviewers.slice(0, 6);
 
   return (
-    <Card className="col-span-2">
+    <Card className="col-span-2 h-full flex flex-col">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Users className="h-5 w-5" />

--- a/components/Analytics/ReviewDistributionChart.tsx
+++ b/components/Analytics/ReviewDistributionChart.tsx
@@ -145,7 +145,7 @@ export function ReviewDistributionChart() {
   };
 
   return (
-    <Card className="col-span-2">
+    <Card className="col-span-2 h-full flex flex-col">
       <CardHeader className="pb-4">
         <CardTitle className="text-lg">Review State Distribution</CardTitle>
         <CardDescription className="text-sm">


### PR DESCRIPTION
## Description
Adjust the height ReviewDistributionCard and ActiveReviewersCard to look the same.
Increase the count of top reviewers in the ActiveReviewersCard from 5 to 6 match the height.

## Related Issue
Fixes #239 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
### Before
<img width="802" height="329" alt="Screenshot 2026-01-25 at 6 00 46 PM" src="https://github.com/user-attachments/assets/c3eca927-8de3-42c3-b51e-7a82cd2d8d79" />
### After
<img width="809" height="365" alt="Screenshot 2026-01-25 at 6 01 03 PM" src="https://github.com/user-attachments/assets/5499b0ef-4626-4fd5-8fcc-1c18689696ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved vertical alignment, spacing, and layout consistency across the analytics dashboard.
  * Enhanced component sizing and flex behavior for better visual presentation.

* **New Features**
  * Expanded reviewer information displayed on the analytics dashboard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->