### PR TITLE
fix: Handle missing leaderboard JSON gracefully instead of crashing

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,86 @@
+/**
+ * Structured logger utility for consistent logging across the application
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, error?: unknown, context?: Record<string, unknown>): void;
+}
+
+class StructuredLogger implements Logger {
+  constructor(private enabled: boolean = true, private minLevel: LogLevel = 'info') {}
+
+  private shouldLog(level: LogLevel): boolean {
+    if (!this.enabled) return false;
+    
+    const levels = ['debug', 'info', 'warn', 'error'];
+    const currentLevelIndex = levels.indexOf(level);
+    const minLevelIndex = levels.indexOf(this.minLevel);
+    
+    return currentLevelIndex >= minLevelIndex;
+  }
+
+  private formatMessage(level: LogLevel, message: string, context?: Record<string, unknown>, error?: unknown) {
+    const timestamp = new Date().toISOString();
+    const logEntry: Record<string, unknown> = {
+      timestamp,
+      level: level.toUpperCase(),
+      message,
+    };
+    
+    if (context) {
+      logEntry.context = context;
+    }
+    
+    if (error) {
+      logEntry.error = error instanceof Error 
+        ? { message: error.message, stack: error.stack } 
+        : error;
+    }
+    
+    return logEntry;
+  }
+
+  debug(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('debug')) {
+      console.debug(JSON.stringify(this.formatMessage('debug', message, context)));
+    }
+  }
+
+  info(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('info')) {
+      console.info(JSON.stringify(this.formatMessage('info', message, context)));
+    }
+  }
+
+  warn(message: string, context?: Record<string, unknown>): void {
+    if (this.shouldLog('warn')) {
+      console.warn(JSON.stringify(this.formatMessage('warn', message, context)));
+    }
+  }
+
+  error(message: string, error?: unknown, context?: Record<string, unknown>): void {
+    if (this.shouldLog('error')) {
+      console.error(JSON.stringify(this.formatMessage('error', message, context, error)));
+    }
+  }
+}
+
+/**
+ * Creates a logger instance with specified configuration
+ * @param enabled - Whether logging is enabled
+ * @param minLevel - Minimum log level to output
+ * @returns Logger instance
+ */
+export function createLogger(enabled: boolean = true, minLevel: LogLevel = 'info'): Logger {
+  return new StructuredLogger(enabled, minLevel);
+}
+
+/**
+ * Default logger instance for general use
+ */
+export const logger = createLogger(process.env.NODE_ENV !== 'test');

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Description
Replaces hard error throwing with graceful fallbacks when leaderboard JSON files are missing or corrupted. Instead of crashing with a 500 error, the page now displays an empty state with the existing "No contributors with points in this period" message.

## Related Issue
Fixes #252

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
Not applicable - this is an error handling improvement that prevents crashes rather than adding visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard reliability: app now falls back to a safe, empty leaderboard and shows a loading state instead of crashing when data is missing, corrupted, or invalid. Structured error handling and validation prevent user-facing failures.

* **Refactor**
  * Simplified rendering flow to consistently reuse the leaderboard view and Suspense-style loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->